### PR TITLE
Adds node-sass package required by email-templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mongodb": "^2.1.18",
     "mongoose": "^4.5.0",
     "nconf": "0.8.4",
+    "node-sass": "^3.10.0",
     "nodemailer": "^2.5.0",
     "request": "2.70.0",
     "slack-notify": "^0.1.6",


### PR DESCRIPTION
Sans `node-sass`, les templates d'email ne peuvent pas être correctement utilisés car `email-templates` utilise `node-sass` pour compiler les fichiers `.scss`.

A noter que `node-sass` est aussi dans d'autres commits d'autres pull-request comme #7.